### PR TITLE
add goreleaser settings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-goreleaser.yaml
+++ b/.github/workflows/validate-goreleaser.yaml
@@ -1,26 +1,23 @@
-name: goreleaser
+name: validate goreleaser.yml
 
-on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+on: push
 
 jobs:
-  goreleaser:
+  validate-goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
-      - name: Set up Go
+          fetch-depth: 1
+      - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - name: Run GoReleaser
+      - name: Validate .goreleaser.yml
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --snapshot --skip-publish --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,35 @@
+project_name: auriga
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./app/cmd
+    binary: auriga
+    env:
+    - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      darwin: darwin
+      linux: linux
+      windows: windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - docs/*
+      - README.md
+      - README_jp.md
+      - .env.sample
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install-modules:
 install-tools:
 	mkdir -p bin; \
 	go install golang.org/x/tools/cmd/goimports@$(GO_TOOLS_VERSION);
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2;
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0;
 	go install github.com/golang/mock/mockgen@v1.6.0;
 
 install: install-go install-modules install-tools


### PR DESCRIPTION
## What I have done
- The following files were added
  - `.goreleaser.yml`: configure goreleaser settings
  - `./github/workflows/validate-goreleaser.yaml`: to validate `./goreleaser.yaml`
  - `./github/workflows/release.yaml`: release workflow using github actions and goreleaser
- bump up `golangci-lint` version 
  - because github actions(lint workflow) occurred [this error](https://github.com/moneyforward/auriga/runs/7819202821?check_suite_focus=true)

## Further comments

- Once this PR is merged, it will be possible to release with the following flow:
  1. merge from develop to main branch.
  2. create a tag (format: `v0.0.0`)  from the main branch: `git tag -a v0.0.0`
  3. push a tag: `git push origin v0.0.0`

## References

- goreleser-actions: https://github.com/goreleaser/goreleaser-action
- goreleaser: https://goreleaser.com/