### PR TITLE
#12 bug fix: Split userIDs and call the user info API

### DIFF
--- a/app/internal/domain/service/slack_reaction_users.go
+++ b/app/internal/domain/service/slack_reaction_users.go
@@ -52,7 +52,7 @@ const (
 //　and calls slackRepository.ListUsersEmail for each chunk.
 func (s *slackReactionUsersService) chunkedListUsersEmail(ctx context.Context, userIDs []string) ([]*model.SlackUserEmail, error) {
 	chunkedUserIDsList := slice.SplitStringSliceInChunks(userIDs, ChunkSizeOfChunkedListUserEmail)
-	var slackUserEmails []*model.SlackUserEmail
+	slackUserEmails := make([]*model.SlackUserEmail, 0, len(chunkedUserIDsList))
 	for _, chunkedUserIDs := range chunkedUserIDsList {
 		userEmails, err := s.slackRepository.ListUsersEmail(ctx, chunkedUserIDs)
 		if err != nil {

--- a/app/internal/domain/service/slack_reaction_users.go
+++ b/app/internal/domain/service/slack_reaction_users.go
@@ -58,9 +58,7 @@ func (s *slackReactionUsersService) chunkedListUsersEmail(ctx context.Context, u
 		if err != nil {
 			return nil, err
 		}
-		for _, userEmail := range userEmails {
-			slackUserEmails = append(slackUserEmails, userEmail)
-		}
+		slackUserEmails = append(slackUserEmails, userEmails...)
 	}
 	return slackUserEmails, nil
 }

--- a/app/pkg/slice/string.go
+++ b/app/pkg/slice/string.go
@@ -31,6 +31,7 @@ func ToStringSet(s []string) []string {
 }
 
 // SplitStringSliceInChunks SplitStringSliceInChunk split slice in chunk
+// if you set chunkSize is less than 1, this function returns a 2 dimensional slice with 1 chunk ([][]string{s}).
 // TODO: Update 1.18+ and use generics
 func SplitStringSliceInChunks(s []string, chunkSize int) (chunks [][]string) {
 	if chunkSize < 1 {

--- a/app/pkg/slice/string.go
+++ b/app/pkg/slice/string.go
@@ -29,3 +29,16 @@ func ToStringSet(s []string) []string {
 	}
 	return set
 }
+
+// SplitStringSliceInChunks SplitStringSliceInChunk split slice in chunk
+// TODO: Update 1.18+ and use generics
+func SplitStringSliceInChunks(s []string, chunkSize int) (chunks [][]string) {
+	if chunkSize < 1 {
+		return append(chunks, s)
+	}
+	for chunkSize < len(s) {
+		chunks = append(chunks, s[:chunkSize])
+		s = s[chunkSize:]
+	}
+	return append(chunks, s)
+}

--- a/app/pkg/slice/string.go
+++ b/app/pkg/slice/string.go
@@ -33,10 +33,11 @@ func ToStringSet(s []string) []string {
 // SplitStringSliceInChunks SplitStringSliceInChunk split slice in chunk
 // if you set chunkSize is less than 1, this function returns a 2 dimensional slice with 1 chunk ([][]string{s}).
 // TODO: Update 1.18+ and use generics
-func SplitStringSliceInChunks(s []string, chunkSize int) (chunks [][]string) {
+func SplitStringSliceInChunks(s []string, chunkSize int) [][]string {
 	if chunkSize < 1 {
-		return append(chunks, s)
+		return [][]string{s}
 	}
+	chunks := make([][]string, 0, len(s)/chunkSize+1)
 	for chunkSize < len(s) {
 		chunks = append(chunks, s[:chunkSize])
 		s = s[chunkSize:]

--- a/app/pkg/slice/string_test.go
+++ b/app/pkg/slice/string_test.go
@@ -93,7 +93,15 @@ func TestSplitStringSliceInChunks(t *testing.T) {
 			want: [][]string{{}},
 		},
 		{
-			name: "OK: s is empty and chunkSize is more than 0",
+			name: "OK: s is empty and chunkSize is equal to 1",
+			args: args{
+				s:         []string{},
+				chunkSize: 1,
+			},
+			want: [][]string{{}},
+		},
+		{
+			name: "OK: s is empty and chunkSize is more than 1",
 			args: args{
 				s:         []string{},
 				chunkSize: 1,

--- a/app/pkg/slice/string_test.go
+++ b/app/pkg/slice/string_test.go
@@ -84,6 +84,22 @@ func TestSplitStringSliceInChunks(t *testing.T) {
 				{"a", "b", "c", "d"},
 			},
 		},
+		{
+			name: "OK: s is empty and chunkSize is 0",
+			args: args{
+				s:         []string{},
+				chunkSize: 0,
+			},
+			want: [][]string{{}},
+		},
+		{
+			name: "OK: s is empty and chunkSize is more than 0",
+			args: args{
+				s:         []string{},
+				chunkSize: 1,
+			},
+			want: [][]string{{}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/app/pkg/slice/string_test.go
+++ b/app/pkg/slice/string_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Money Forward, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitStringSliceInChunks(t *testing.T) {
+	type args struct {
+		s         []string
+		chunkSize int
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]string
+	}{
+		{
+			name: "OK: all elements(slices) are the same length (chunk size)",
+			args: args{
+				s:         []string{"a", "b", "c", "d"},
+				chunkSize: 2,
+			},
+			want: [][]string{
+				{"a", "b"},
+				{"c", "d"},
+			},
+		},
+		{
+			name: "OK: all elements(slices) are NOT the same length (chunk size)",
+			args: args{
+				s:         []string{"a", "b", "c", "d", "e"},
+				chunkSize: 2,
+			},
+			want: [][]string{
+				{"a", "b"},
+				{"c", "d"},
+				{"e"},
+			},
+		},
+		{
+			name: "OK: slices length is chunk size",
+			args: args{
+				s:         []string{"a", "b", "c", "d"},
+				chunkSize: 4,
+			},
+			want: [][]string{
+				{"a", "b", "c", "d"},
+			},
+		},
+		{
+			name: "OK: chunk size is bigger than slices length",
+			args: args{
+				s:         []string{"a", "b", "c", "d"},
+				chunkSize: 5,
+			},
+			want: [][]string{
+				{"a", "b", "c", "d"},
+			},
+		},
+		{
+			name: "OK: chunk size is less than 1",
+			args: args{
+				s:         []string{"a", "b", "c", "d"},
+				chunkSize: 0,
+			},
+			want: [][]string{
+				{"a", "b", "c", "d"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SplitStringSliceInChunks(tt.args.s, tt.args.chunkSize); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitStringSliceInChunks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
close #12 
## Overview

- #12 
- split userIDs (API params) before Auriga calls the userInfoAPI.

## Changes

- add `SplitStringSliceInChunks` function in `app/pkg/slice` to enable to create chunked slices from a slice and chunkSize.
- add `chunkedListUsersEmail` method in `slackReactionUsersService` that is able to split a slice (userIDs) before calling user info API, and it can call the API for each chunked slice. 
- I decide `ChunkSizeOfChunkedListUserEmail = 20` because I confirm that this chunkSize shoud be set less than 30, but its a number we can afford.

## Scope of Impact

- No impact on users but it affects how Auriga calls userInfoAPI.

## How to check the operation

I've checked Auriga's operation on a test environment.

