### PR TITLE
When Auriga replies to email addresses, the message is divided into 50 lines each.

### DIFF
--- a/app/internal/domain/service/slack_response.go
+++ b/app/internal/domain/service/slack_response.go
@@ -75,7 +75,6 @@ func (s *slackResponseService) postEmailList(ctx context.Context, channelID stri
 func (s *slackResponseService) ReplyEmailList(ctx context.Context, event *slackevents.AppMentionEvent, emails []*model.SlackUserEmail) error {
 	if len(emails) <= lineSizeOfPostEmailList-1 {
 		var b strings.Builder
-		b.Grow(len(emails) + 1)
 		b.WriteString("参加者一覧")
 		for _, email := range emails {
 			b.WriteString("\n" + email.Email)

--- a/app/internal/domain/service/slack_response.go
+++ b/app/internal/domain/service/slack_response.go
@@ -31,19 +31,19 @@ type SlackResponseService interface {
 	ReplyHelp(ctx context.Context, event *slackevents.AppMentionEvent) error
 }
 
-type slackErrorResponseService struct {
+type slackResponseService struct {
 	slackRepository repository.SlackRepository
 	errorRepository repository.ErrorRepository
 }
 
-func NewSlackResponseService(factory repository.Factory) *slackErrorResponseService {
-	return &slackErrorResponseService{
+func NewSlackResponseService(factory repository.Factory) *slackResponseService {
+	return &slackResponseService{
 		slackRepository: factory.SlackRepository(),
 		errorRepository: factory.ErrorRepository(),
 	}
 }
 
-func (s *slackErrorResponseService) ReplyEmailList(ctx context.Context, event *slackevents.AppMentionEvent, emails []*model.SlackUserEmail) error {
+func (s *slackResponseService) ReplyEmailList(ctx context.Context, event *slackevents.AppMentionEvent, emails []*model.SlackUserEmail) error {
 	msg := "参加者一覧\n"
 	for _, email := range emails {
 		msg += email.Email
@@ -58,7 +58,7 @@ func (s *slackErrorResponseService) ReplyEmailList(ctx context.Context, event *s
 	return err
 }
 
-func (s *slackErrorResponseService) ReplyError(ctx context.Context, event *slackevents.AppMentionEvent, err error) error {
+func (s *slackResponseService) ReplyError(ctx context.Context, event *slackevents.AppMentionEvent, err error) error {
 	var msg string
 	if s.errorRepository.ErrThreadNotFound(err) {
 		msg += "スレッドで呼び出してね:neko_namida:"
@@ -75,7 +75,7 @@ func (s *slackErrorResponseService) ReplyError(ctx context.Context, event *slack
 	return err
 }
 
-func (s *slackErrorResponseService) ReplyHelp(ctx context.Context, event *slackevents.AppMentionEvent) error {
+func (s *slackResponseService) ReplyHelp(ctx context.Context, event *slackevents.AppMentionEvent) error {
 	msg := "[使い方]\n" +
 		"1. スレッドで `@Auriga :sanka:` のようにAurigaを呼び出し、リアクションを指定してください。\n" +
 		"2. スレッドの開始メッセージに指定のリアクションをしたユーザのメールアドレス一覧を返します。\n" +

--- a/app/internal/domain/service/slack_response.go
+++ b/app/internal/domain/service/slack_response.go
@@ -76,9 +76,9 @@ func (s *slackResponseService) ReplyEmailList(ctx context.Context, event *slacke
 	if len(emails) <= lineSizeOfPostEmailList-1 {
 		var b strings.Builder
 		b.Grow(len(emails) + 1)
-		b.WriteString("参加者一覧\n")
+		b.WriteString("参加者一覧")
 		for _, email := range emails {
-			b.WriteString(email.Email)
+			b.WriteString("\n" + email.Email)
 		}
 		return s.slackRepository.PostMessage(ctx, event.Channel, b.String(), event.ThreadTimeStamp)
 	}

--- a/app/internal/domain/service/slack_response.go
+++ b/app/internal/domain/service/slack_response.go
@@ -57,7 +57,7 @@ const (
 // postEmailList method posts emailList using slack postMessageAPI.
 // The chunkedLines are generated and requested for each chunk,
 // because of considering the limit the number of characters of slackAPI.
-func (s *slackResponseService) postEmailList(ctx context.Context, channelID, message, ts string) error {
+func (s *slackResponseService) postEmailList(ctx context.Context, channelID, message, ts string, lineSizeOfPostEmailList int) error {
 	lines := strings.Split(message, "\n")
 	chunkedLines := slice.SplitStringSliceInChunks(lines, lineSizeOfPostEmailList)
 	for _, chunkedLine := range chunkedLines {
@@ -75,7 +75,7 @@ func (s *slackResponseService) ReplyEmailList(ctx context.Context, event *slacke
 		msg += email.Email
 		msg += "\n"
 	}
-	return s.postEmailList(ctx, event.Channel, msg, event.ThreadTimeStamp)
+	return s.postEmailList(ctx, event.Channel, msg, event.ThreadTimeStamp, lineSizeOfPostEmailList)
 }
 
 func (s *slackResponseService) ReplyError(ctx context.Context, event *slackevents.AppMentionEvent, err error) error {

--- a/app/internal/domain/service/slack_response_test.go
+++ b/app/internal/domain/service/slack_response_test.go
@@ -86,7 +86,7 @@ func Test_slackErrorResponseService_ReplyEmailList(t *testing.T) {
 			if tt.prepare != nil {
 				tt.prepare(msr)
 			}
-			s := &slackErrorResponseService{
+			s := &slackResponseService{
 				slackRepository: msr,
 				errorRepository: mer,
 			}
@@ -216,7 +216,7 @@ func Test_slackErrorResponseService_ReplyError(t *testing.T) {
 			if tt.prepare != nil {
 				tt.prepare(mer, msr)
 			}
-			s := &slackErrorResponseService{
+			s := &slackResponseService{
 				slackRepository: msr,
 				errorRepository: mer,
 			}
@@ -286,7 +286,7 @@ func Test_slackErrorResponseService_ReplyHelp(t *testing.T) {
 			if tt.prepare != nil {
 				tt.prepare(mer, msr)
 			}
-			s := &slackErrorResponseService{
+			s := &slackResponseService{
 				slackRepository: msr,
 				errorRepository: mer,
 			}

--- a/app/internal/domain/service/slack_response_test.go
+++ b/app/internal/domain/service/slack_response_test.go
@@ -157,7 +157,7 @@ func Test_slackErrorResponseService_ReplyEmailList(t *testing.T) {
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				msr.EXPECT().PostMessage(gomock.Any(), "sampleChannel",
-					"参加者一覧\nsample01@example.com\nsample02@example.com\n",
+					"参加者一覧\nsample01@example.com\nsample02@example.com",
 					"sampleThreadTimeStamp").Return(nil)
 			},
 		},
@@ -175,7 +175,7 @@ func Test_slackErrorResponseService_ReplyEmailList(t *testing.T) {
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				msr.EXPECT().PostMessage(gomock.Any(), "sampleChannel",
-					"参加者一覧\nsample01@example.com\nsample02@example.com\n",
+					"参加者一覧\nsample01@example.com\nsample02@example.com",
 					"sampleThreadTimeStamp").Return(errors.New("sample error"))
 			},
 			wantErr: true,

--- a/app/internal/domain/service/slack_response_test.go
+++ b/app/internal/domain/service/slack_response_test.go
@@ -57,10 +57,11 @@ func convertEmailsToStrings(emails []*model.SlackUserEmail) []string {
 }
 
 func Test_slackResponseService_postEmailList(t *testing.T) {
-	channelID := "cid"
-	ts := "ts"
+
 	type args struct {
 		emails []*model.SlackUserEmail
+		cid    string
+		ts     string
 	}
 	tests := []struct {
 		name    string
@@ -72,11 +73,13 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 			name: "OK: number of emails = 1",
 			args: args{
 				emails: createEmails(0, 1),
+				ts:     "ts",
+				cid:    "cid",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
 					msr.EXPECT().PostMessage(
-						gomock.Any(), channelID, createMessage("参加者一覧", createEmails(0, 1)), ts).
+						gomock.Any(), "cid", createMessage("参加者一覧", createEmails(0, 1)), "ts").
 						Return(nil),
 				)
 			},
@@ -85,11 +88,13 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 			name: "OK: number of emails = lineSizeOfPostEmailList - 1",
 			args: args{
 				emails: createEmails(0, lineSizeOfPostEmailList-1),
+				ts:     "ts",
+				cid:    "cid",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
 					msr.EXPECT().PostMessage(
-						gomock.Any(), channelID, createMessage("参加者一覧", createEmails(0, lineSizeOfPostEmailList-1)), ts).
+						gomock.Any(), "cid", createMessage("参加者一覧", createEmails(0, lineSizeOfPostEmailList-1)), "ts").
 						Return(nil),
 				)
 			},
@@ -98,14 +103,16 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 			name: "OK: number of emails = lineSizeOfPostEmailList",
 			args: args{
 				emails: createEmails(0, lineSizeOfPostEmailList),
+				ts:     "ts",
+				cid:    "cid",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
 					msr.EXPECT().PostMessage(
-						gomock.Any(), channelID, createMessage("参加者一覧", createEmails(0, lineSizeOfPostEmailList-1)), ts).
+						gomock.Any(), "cid", createMessage("参加者一覧", createEmails(0, lineSizeOfPostEmailList-1)), "ts").
 						Return(nil),
 					msr.EXPECT().PostMessage(
-						gomock.Any(), channelID, createMessage("", createEmails(lineSizeOfPostEmailList-1, 1)), ts).
+						gomock.Any(), "cid", createMessage("", createEmails(lineSizeOfPostEmailList-1, 1)), "ts").
 						Return(nil),
 				)
 			},
@@ -125,7 +132,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 				slackRepository: msr,
 				errorRepository: mer,
 			}
-			if err := s.postEmailList(ctx, channelID, tt.args.emails, ts); (err != nil) != tt.wantErr {
+			if err := s.postEmailList(ctx, tt.args.cid, tt.args.emails, tt.args.ts); (err != nil) != tt.wantErr {
 				t.Errorf("postEmailList() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
# Overview

- Part of https://github.com/moneyforward/auriga/issues/13
- I thought about handling the error about the character limitation in the repository layer, since it is time-consuming, I simply handled it in the service layer.
- I'd modified only `slackResponseService` because the number of characters would increase when Auriga reply email addresses.
- and, chore.

# Changes

- rename: `slackErrorResponseService` to `slackResponseService`
- add `slackResponseService.postEmailList` method, and add test