### PR TITLE
Change message ephemeral

### DIFF
--- a/.github/workflows/validate-goreleaser.yaml
+++ b/.github/workflows/validate-goreleaser.yaml
@@ -15,9 +15,9 @@ jobs:
         with:
           go-version: 1.17
       - name: Validate .goreleaser.yml
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --snapshot --skip-publish --rm-dist --debug
+          args: release --snapshot --skip=publish --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: auriga
 before:
   hooks:
@@ -6,22 +7,19 @@ builds:
   - main: ./app/cmd
     binary: auriga
     env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
-    format_overrides:
-      - goos: windows
-        format: zip
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
       - docs/*
       - README.md

--- a/app/internal/domain/service/slack_response.go
+++ b/app/internal/domain/service/slack_response.go
@@ -57,14 +57,14 @@ const (
 // postEmailList method posts emailList using slack postMessageAPI.
 // The chunkedLines are generated and requested for each chunk,
 // because of considering the limit the number of characters of slackAPI.
-func (s *slackResponseService) postEmailList(ctx context.Context, channelID string, emails []*model.SlackUserEmail, ts string) error {
+func (s *slackResponseService) postEmailList(ctx context.Context, channelID string, emails []*model.SlackUserEmail, ts string, userID string) error {
 	lines := append(make([]string, 0, len(emails)+1), "参加者一覧")
 	for _, email := range emails {
 		lines = append(lines, email.Email)
 	}
 	chunkedLines := slice.SplitStringSliceInChunks(lines, lineSizeOfPostEmailList)
 	for _, chunkedLine := range chunkedLines {
-		err := s.slackRepository.PostMessage(ctx, channelID, strings.Join(chunkedLine, "\n"), ts)
+		err := s.slackRepository.PostEphemeral(ctx, channelID, strings.Join(chunkedLine, "\n"), ts, userID)
 		if err != nil {
 			return err
 		}
@@ -79,10 +79,10 @@ func (s *slackResponseService) ReplyEmailList(ctx context.Context, event *slacke
 		for _, email := range emails {
 			b.WriteString("\n" + email.Email)
 		}
-		return s.slackRepository.PostMessage(ctx, event.Channel, b.String(), event.ThreadTimeStamp)
+		return s.slackRepository.PostEphemeral(ctx, event.Channel, b.String(), event.ThreadTimeStamp, event.User)
 	}
 
-	return s.postEmailList(ctx, event.Channel, emails, event.ThreadTimeStamp)
+	return s.postEmailList(ctx, event.Channel, emails, event.ThreadTimeStamp, event.User)
 }
 
 func (s *slackResponseService) ReplyError(ctx context.Context, event *slackevents.AppMentionEvent, err error) error {
@@ -95,8 +95,8 @@ func (s *slackResponseService) ReplyError(ctx context.Context, event *slackevent
 	}
 	if s.errorRepository.ErrUserNotFound(err) {
 		msg += "参加者はいないようです:neko_namida:"
-		return s.slackRepository.PostMessage(
-			ctx, event.Channel, msg, event.ThreadTimeStamp,
+		return s.slackRepository.PostEphemeral(
+			ctx, event.Channel, msg, event.ThreadTimeStamp, event.User,
 		)
 	}
 	return err

--- a/app/internal/domain/service/slack_response_test.go
+++ b/app/internal/domain/service/slack_response_test.go
@@ -62,7 +62,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 		emails []*model.SlackUserEmail
 		cid    string
 		ts     string
-		user   string
+		userID string
 	}
 	tests := []struct {
 		name    string
@@ -76,7 +76,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 				emails: createEmails(0, 1),
 				ts:     "ts",
 				cid:    "cid",
-				user:   "sampleUser",
+				userID: "sampleUser",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
@@ -92,7 +92,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 				emails: createEmails(0, lineSizeOfPostEmailList-1),
 				ts:     "ts",
 				cid:    "cid",
-				user:   "sampleUser",
+				userID: "sampleUser",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
@@ -108,7 +108,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 				emails: createEmails(0, lineSizeOfPostEmailList),
 				ts:     "ts",
 				cid:    "cid",
-				user:   "sampleUser",
+				userID: "sampleUser",
 			},
 			prepare: func(msr *mock_repository.MockSlackRepository) {
 				gomock.InOrder(
@@ -136,7 +136,7 @@ func Test_slackResponseService_postEmailList(t *testing.T) {
 				slackRepository: msr,
 				errorRepository: mer,
 			}
-			if err := s.postEmailList(ctx, tt.args.cid, tt.args.emails, tt.args.ts, tt.args.user); (err != nil) != tt.wantErr {
+			if err := s.postEmailList(ctx, tt.args.cid, tt.args.emails, tt.args.ts, tt.args.userID); (err != nil) != tt.wantErr {
 				t.Errorf("postEmailList() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Changed all statements by Auriga to EphemeralMessage. 
I considered refactoring as well, but since the differences would be significant, I decided to limit the changes to the above for now

https://moneyforward.slack.com/archives/C03CB6NF2G6/p1720156080683339